### PR TITLE
feat (api): update workflow execution to support multiple next nodes

### DIFF
--- a/api/src/executions/execute-workflow.ts
+++ b/api/src/executions/execute-workflow.ts
@@ -5,14 +5,16 @@ import { ExecuteWorkflowInput } from "./types";
 const executeWorkflow = async (input: ExecuteWorkflowInput) => {
   await executeNode(input);
 
-  const nextNodeId = ExecutionHelper.getNextNodeId(input)
+  const nextNodeId = ExecutionHelper.getNextNodesId(input)
 
   if (!nextNodeId) {
     console.log("no more nodes to process")
     return;
   }
 
-  await executeWorkflow({ ...input, nodeId: nextNodeId})
+  nextNodeId.map(async (node) => {
+    await executeWorkflow({ ...input, nodeId: node})
+  }) 
 };
 
 export default executeWorkflow;

--- a/api/src/executions/helper.ts
+++ b/api/src/executions/helper.ts
@@ -4,9 +4,10 @@ import { generateDynamicObjectZodSchema } from "../utils/generateDynamicZodSchem
 import { ExecuteWorkflowInput } from "./types";
 
 class ExecutionHelper {
-  // TODO: add support for multiple next nodes
-  static getNextNodeId = (input: ExecuteWorkflowInput) => {
-    return input.workflow.connections.find(item => item.source === input.nodeId)?.target;
+  static getNextNodesId = (input: ExecuteWorkflowInput) : string[] => {
+    return input.workflow.connections
+      .filter(item => item.source === input.nodeId)
+      .map(item => item.target);
   };
 
   static getNodeFromId = (input: ExecuteWorkflowInput) => {


### PR DESCRIPTION
Closes #9 

### Changes
- Changed getNextNodeId to getNextNodesId to return an array of next node IDs.
- Updated executeWorkflow to handle multiple next nodes concurrently.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable branching by executing multiple next nodes during workflow execution.
> 
> - **Backend**
>   - **Workflow execution**:
>     - Replace `getNextNodeId` with `getNextNodesId` returning an array of targets from `workflow.connections` in `api/src/executions/helper.ts`.
>     - Update `api/src/executions/execute-workflow.ts` to iterate over returned node IDs and invoke `executeWorkflow` for each.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8018441441922d22eb06be5445879cfafbedca51. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->